### PR TITLE
Fix uppercase issue with Træfik's HostRegexp rules

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -160,7 +160,7 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 		return r.regexp.MatchString(path)
 	}
 
-	return r.regexp.MatchString(getHost(req))
+	return r.regexp.MatchString(strings.ToLower(getHost(req)))
 }
 
 // url builds a URL part using the given values.


### PR DESCRIPTION
In this PR, I suggest a trivial fix for matching patterns to lowercased hostname in order to support any uppercase letters.

Fixes issue containous/traefik#3930.

Related unit test has been submitted in PR containous/traefik#3931