### PR TITLE
Use req.Host because it already handles absolute-form Host

### DIFF
--- a/regexp.go
+++ b/regexp.go
@@ -166,7 +166,7 @@ func (r *routeRegexp) Match(req *http.Request, match *RouteMatch) bool {
 		return r.regexp.MatchString(path)
 	}
 
-	return r.regexp.MatchString(getHost(req))
+	return r.regexp.MatchString(req.Host)
 }
 
 // url builds a URL part using the given values.
@@ -263,7 +263,7 @@ type routeRegexpGroup struct {
 func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) {
 	// Store host variables.
 	if v.host != nil {
-		host := getHost(req)
+		host := req.Host
 		matches := v.host.regexp.FindStringSubmatchIndex(host)
 		if len(matches) > 0 {
 			extractVars(host, matches, v.host.varsN, m.Vars)
@@ -302,20 +302,6 @@ func (v *routeRegexpGroup) setMatch(req *http.Request, m *RouteMatch, r *Route) 
 			extractVars(queryURL, matches, q.varsN, m.Vars)
 		}
 	}
-}
-
-// getHost tries its best to return the request host.
-func getHost(r *http.Request) string {
-	if r.URL.IsAbs() {
-		return r.URL.Host
-	}
-	host := r.Host
-	// Slice off any port information.
-	if i := strings.Index(host, ":"); i != -1 {
-		host = host[:i]
-	}
-	return host
-
 }
 
 func extractVars(input string, matches []int, names []string, output map[string]string) {


### PR DESCRIPTION
As specified in the go doc, `req.Host` already handles the hostname in the URL itself.

https://github.com/golang/go/blob/9068c6844dc0f0100bd810ad73dbf877bb92507b/src/net/http/request.go#L220-L224

```go
// For server requests, Host specifies the host on which the
// URL is sought. For HTTP/1 (per RFC 7230, section 5.4), this
// is either the value of the "Host" header or the host name
// given in the URL itself.
```
And in the code:
https://github.com/golang/go/blob/9068c6844dc0f0100bd810ad73dbf877bb92507b/src/net/http/request.go#L1099-L1102

```go
req.Host = req.URL.Host
if req.Host == "" {
   req.Host = req.Header.get("Host")
}
```

Moreover, according to section 14.23 of RFC2616 the Host header can include the port number. So the part removing the port is not necessary.